### PR TITLE
[ci] Switch from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,0 +1,31 @@
+name: Build Status
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    name: Test on Node.js ${{ matrix.node-version }} in ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: npm install and test
+      run: |
+        npm install
+        npm test
+      env:
+        CI: true

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -2,8 +2,6 @@ name: Build Status
 
 on:
   push:
-    branches:
-    - master
   pull_request:
     branches:
     - master
@@ -13,6 +11,7 @@ jobs:
     name: Test on Node.js ${{ matrix.node-version }} in ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         node-version: [8.x, 10.x, 12.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-os:
-  - linux
-  - osx
-  - windows
-language: node_js
-node_js:
-  - '12'
-  - '10'
-  - '8'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # lib-name
 
-<!-- ![](https://img.shields.io/github/license/niktekusho/lib-name.svg) [![](https://img.shields.io/npm/v/lib-name.svg)](https://www.npmjs.com/package/lib-name) [![Build Status](https://travis-ci.org/niktekusho/lib-name.svg?branch=master)](https://travis-ci.org/niktekusho/lib-name) [![](https://img.shields.io/node/v/lib-name.svg)](https://www.npmjs.com/package/lib-name) [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/sindresorhus/xo) [![Maintainability](https://api.codeclimate.com/v1/badges/744538fb7227c1a86bea/maintainability)](https://codeclimate.com/github/niktekusho/lib-name/maintainability) [![](https://img.shields.io/bundlephobia/minzip/lib-name.svg)](https://bundlephobia.com/result?p=lib-name) -->
+![](https://github.com/niktekusho/lib-name/workflows/Build%20Status/badge.svg)
+
+<!-- ![](https://img.shields.io/github/license/niktekusho/lib-name.svg) [![](https://img.shields.io/npm/v/lib-name.svg)](https://www.npmjs.com/package/lib-name) [![](https://img.shields.io/node/v/lib-name.svg)](https://www.npmjs.com/package/lib-name) [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/sindresorhus/xo) [![](https://img.shields.io/bundlephobia/minzip/lib-name.svg)](https://bundlephobia.com/result?p=lib-name) -->
 
 > Lib Description
 


### PR DESCRIPTION
## Proposed changes

Switch CI builds from Travis CI to GitHub Actions.
The workflow should run the `npm test` task (after `npm install`, of course).
The new workflow should run using the same environments used in Travis CI, including macOs, Ubuntu, and Windows OSes, and the currently maintained Node.js versions.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist is a simple reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](./docs/CONTRIBUTING.md) document
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)